### PR TITLE
Improved 3DVision protocol and frame timing

### DIFF
--- a/3DVisionAVR/IREmitter.h
+++ b/3DVisionAVR/IREmitter.h
@@ -2,10 +2,10 @@
 #ifndef _IREMITTER_H_
 #define _IREMITTER_H_
 
-// Frame exposure duration in half-microseconds (@16MHz)
-#define FRAME_DURATION  (2*4000)
+// Duration between close to open eye frames - in half-microseconds (@16MHz)
+#define FRAME_DURATION  (2*1000)
 // Time between sync trigger and start of IR token (same units)
-#define FRAME_PAN       (10)
+#define FRAME_PAN       (2*3000) // for 120Hz display (use 2*3400 for 100Hz)
 
 // INT1, pin 2 on "Arduino Pro Micro"
 #define SYNCIN          1

--- a/3DVisionAVR/IRProtocols.h
+++ b/3DVisionAVR/IRProtocols.h
@@ -23,11 +23,15 @@ const IR_Protocol_t IRProt_Xpand = {
 	.indices = { 0,0, 5,0 },
 	.timings = { 18,20,18,20,18,  18,60,18 }
 };
+
+// For 3D Vision only, indexed in this order:
+// [0]: Close left eye  [1] Open right eye
+// [2]: Close right eye [3]: Open left eye
 const IR_Protocol_t IRProt_3DVision = {
-	.sizes   = { 3,3, 1,3 },
-	.indices = { 0,3, 6,7 },
-	.timings = { 23,46,31,  23,78,40, 
-	             43,        23,21,24 }
+	.sizes   = { 3,3, 3,1 },
+	.indices = { 0,3, 6,9 },
+	.timings = { 23,21,24,  23,46,31,
+	             23,78,40,  43 }
 };
 const IR_Protocol_t IRProt_Sharp = {
 	.sizes   = { 15,0, 15,0 },


### PR DESCRIPTION
Used a [logic analyzer](https://u.cubeupload.com/logix3d/Logiczoomout.png) on the official 3D Vision pyramid to get a closer match on when issue each IR index. This keeps each eye open longer to improve the brightness of the image. Noticed the timing is a bit different if you run the monitor at 100Hz, but I would assume setting the default for 120Hz makes the most sense. 
